### PR TITLE
Improve the setup script 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ __pycache__/
 Pipfile.lock
 *.log
 *~
+oslo.messaging/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM grahamdumpleton/mod-wsgi-docker:python-3.5-onbuild
+ARG LOCAL_PKG
+ARG TRANSPORT_URL
+RUN mkdir /setup
+ADD ./* /setup
+RUN pip install -r /setup/requirements.txt
+RUN ls /setup
+RUN if [ -d /setup/$LOCAL_PKG ]; then cd /setup/$LOCAL_PKG; python setup.py develop; fi
+CMD ["server.wsgi"]

--- a/Pipfile
+++ b/Pipfile
@@ -9,6 +9,7 @@ verify_ssl = true
 pbr = "*"
 uwsgi = "*"
 oslo-messaging = "*"
+oslo-utils = "*"
 oslo-log = "*"
 eventlet = "*"
 

--- a/Pipfile
+++ b/Pipfile
@@ -6,6 +6,7 @@ verify_ssl = true
 [dev-packages]
 
 [packages]
+pbr = "*"
 uwsgi = "*"
 oslo-messaging = "*"
 oslo-log = "*"

--- a/Pipfile
+++ b/Pipfile
@@ -6,6 +6,7 @@ verify_ssl = true
 [dev-packages]
 
 [packages]
+niet = "*"
 pbr = "*"
 uwsgi = "*"
 oslo-messaging = "*"

--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@
     pipenv shell
 
 The setup installs the neccessary python dependencies, and runs a
-rabbitmq server in a docker container. After the installation, you are
-in the virtual env prepared by `pipenv` for you.
+rabbitmq server in a podman or docker container. After the installation, you
+are in the virtual env prepared by `pipenv` for you.
 
 ## Test 1: thread-based server
 

--- a/README.md
+++ b/README.md
@@ -92,3 +92,35 @@ the RPC service is now accessible on localhost:8090:
     curl http://localhost:8090/\?num\=1336
 
 As in Test 2, the heartbeat can be inspected after the first API call.
+
+## Test 4: Apache mod_wsgi server with monkey patched environment
+
+Run the original RPC server as in test 1
+in an apache mod_wsgi environment
+with and monkey patched with eventlet, and the API service runs
+under a eventlet-based WSGI server (by example):
+
+```
+pipenv run ./start-oslo-mod_wsgi.sh &
+./eventlet-api.py > eventlet-api.log &
+```
+
+The previous example use upstream release of oslo.messaging and installed
+as a dependencies like in test 1 but you can choose to install and use a
+local clone of `oslo.messaging` or a local copy of another dependencies
+(`oslo.utils` by example or `pyamqp`) by passing the root path of your local
+clone as a parameter of your command, like the following example:
+
+```
+pipenv run ./start-oslo-mod_wsgi.sh ~/dev/openstack/oslo.messaging &
+./eventlet-api.py > eventlet-api.log &
+```
+
+Or local clone will be installed and used in your fresh created
+apache mod_wsgi container.
+
+the RPC service is now accessible on localhost:8090:
+
+    curl http://localhost:8090/\?num\=1336
+
+As in Test 2, the heartbeat can be inspected after the first API call.

--- a/README.md
+++ b/README.md
@@ -1,14 +1,50 @@
 # Behaviour of the AMQP heartbeat thread under various execution models
 
-## Quick setup
+The main goal of this project is to test and develop [oslo.messaging](https://github.com/openstack/oslo.messaging) behaviors related to rabbitmq and especially the [rabbitmq driver](https://docs.openstack.org/oslo.messaging/latest/configuration/opts.html#oslo-messaging-rabbit)
 
-    pipenv install
-    pipenv run ./setup-containers.sh
-    pipenv shell
+## Setup
 
-The setup installs the neccessary python dependencies, and runs a
-rabbitmq server in a podman or docker container. After the installation, you
-are in the virtual env prepared by `pipenv` for you.
+You can use setup your environment in 2 ways:
+- The quick setup
+- The debug setup
+
+The *quick setup* will install dependencies from the internet by using
+the latest available releases of the needed requirements.
+
+The *debug setup* let's you setup your virtual environment free from any
+dependencies, and in a second time it allow to you to install local packages
+in a development mode to let's you tweak, modify and test your changes.
+
+### Quick setup
+
+```
+pipenv install
+pipenv run ./setup-containers.sh
+pipenv shell
+```
+
+The setup installs the neccessary python dependencies from the latest
+available official releases, and runs a rabbitmq server in a podman or docker
+container. After the installation, you are in the virtual env prepared
+by `pipenv` for you.
+
+### Debug setup
+
+```
+pipenv
+pipenv run ./setup-containers.sh
+pipenv install -e /local/path/to/your/oslo.messaging/clone/oslo.messaging
+pipenv shell
+pip list | grep "oslo.messaging"
+oslo.messaging     9.7.2.dev1 /local/path/to/your/oslo.messaging/clone/oslo.messaging
+```
+
+The debug setup runs a rabbitmq server in a podman or docker container.
+This method let's you install a local version of your oslo.messaging
+to help you to modify, debug, and test.
+After the installation, you are in the virtual env prepared
+by `pipenv` for you and you can add changes to your oslo.messaging clone to
+test them interactively by using the following scenarios.
 
 ## Test 1: thread-based server
 

--- a/heartbeat.py
+++ b/heartbeat.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python
+import argparse
+import threading
+
+import eventlet
+
+from oslo_config import cfg
+from oslo_utils import eventletutils
+import oslo_messaging
+import time
+import log  # noqa
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--eventlet-turned-on', action='store_true',
+                        help='turn on eventlet and monkey patch the env')
+    parser.add_argument("--heartbeat-timeout", help="the heartbeat timeout",
+                        default=60)
+    args = parser.parse_args()
+    if args.eventlet_turned_on:
+        print("----------------------------------------------")
+        print("/!\  Running a monkey patched environment  /!\\")
+        print("----------------------------------------------")
+        eventlet.monkey_patch()
+
+    event = eventletutils.Event()
+    transport_url = 'rabbit://testuser:testpwd@localhost:5672/'
+    transport = oslo_messaging.get_transport(cfg.CONF, transport_url)
+    conn = transport._driver._get_connection()
+    conn.ensure(method=lambda: True)
+    event.wait()
+    conn._heartbeat_stop()
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+niet
+pbr
+oslo.messaging
+oslo.utils
+oslo.log
+eventlet
+

--- a/runtime.sh
+++ b/runtime.sh
@@ -1,0 +1,13 @@
+#!/bin/bash -eux
+if ! [[ $_ != $0 ]]; then
+    echo "This is supposed to be sourced!"
+    exit 1
+fi
+CONTAINER_RUNTIME=podman
+if [ -z "$(which podman)" ]; then
+    if [ -z "$(which docker)" ]; then
+        echo "No container runtimes are available please install podman or docker first"
+        exit 1
+    fi
+    CONTAINER_RUNTIME=docker
+fi

--- a/server.py
+++ b/server.py
@@ -1,4 +1,7 @@
 #!/usr/bin/env python
+import argparse
+
+import eventlet
 
 from oslo_config import cfg
 import oslo_messaging
@@ -12,13 +15,30 @@ class TestEndpoint(object):
         return arg+1
 
 
-transport_url = 'rabbit://testuser:testpwd@localhost:5672/'
-transport = oslo_messaging.get_rpc_transport(cfg.CONF)
-target = oslo_messaging.Target(topic='test', server='myname')
-endpoints = [TestEndpoint()]
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--eventlet-turned-on', action='store_true',
+                        help='turn on eventlet and monkey patch the env')
+    parser.add_argument("--heartbeat-timeout", help="the heartbeat timeout",
+                        default=60)
+    args = parser.parse_args()
+    if args.eventlet_turned_on:
+        print("----------------------------------------------")
+        print("/!\  Running a monkey patched environment  /!\\")
+        print("----------------------------------------------")
+        eventlet.monkey_patch()
 
-server = oslo_messaging.get_rpc_server(transport, target, endpoints,
-                                       executor='threading')
-server.start()
-while True:
-    time.sleep(1)
+    transport_url = 'rabbit://testuser:testpwd@localhost:5672/'
+    transport = oslo_messaging.get_rpc_transport(cfg.CONF)
+    target = oslo_messaging.Target(topic='test', server='myname')
+    endpoints = [TestEndpoint()]
+    
+    server = oslo_messaging.get_rpc_server(transport, target, endpoints,
+                                           executor='threading')
+    server.start()
+    while True:
+        time.sleep(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/server.py
+++ b/server.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 import argparse
+import os
 
 import eventlet
 
@@ -15,6 +16,26 @@ class TestEndpoint(object):
         return arg+1
 
 
+def run_oslo(eventlet_turned_on=False):
+    if eventlet_turned_on:
+        print("----------------------------------------------")
+        print("/!\  Running a monkey patched environment  /!\\")
+        print("----------------------------------------------")
+        eventlet.monkey_patch()
+
+    default_transport_url = 'rabbit://testuser:testpwd@localhost:5672/'
+    transport_url = os.getenv('TRANSPORT_URL', default=default_transport_url)
+    transport = oslo_messaging.get_rpc_transport(cfg.CONF)
+    target = oslo_messaging.Target(topic='test', server='myname')
+    endpoints = [TestEndpoint()]
+    
+    server = oslo_messaging.get_rpc_server(
+        transport, target, endpoints, executor='threading')
+    server.start()
+    while True:
+        time.sleep(1)
+
+
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument('--eventlet-turned-on', action='store_true',
@@ -22,22 +43,7 @@ def main():
     parser.add_argument("--heartbeat-timeout", help="the heartbeat timeout",
                         default=60)
     args = parser.parse_args()
-    if args.eventlet_turned_on:
-        print("----------------------------------------------")
-        print("/!\  Running a monkey patched environment  /!\\")
-        print("----------------------------------------------")
-        eventlet.monkey_patch()
-
-    transport_url = 'rabbit://testuser:testpwd@localhost:5672/'
-    transport = oslo_messaging.get_rpc_transport(cfg.CONF)
-    target = oslo_messaging.Target(topic='test', server='myname')
-    endpoints = [TestEndpoint()]
-    
-    server = oslo_messaging.get_rpc_server(transport, target, endpoints,
-                                           executor='threading')
-    server.start()
-    while True:
-        time.sleep(1)
+    run_oslo(args.eventlet_turned_on)
 
 
 if __name__ == "__main__":

--- a/server.wsgi
+++ b/server.wsgi
@@ -1,0 +1,11 @@
+import sys
+sys.path.append('/setup')
+import server
+
+
+def application(environ, start_response):
+    server.run_oslo(eventlet_turned_on=True)
+    num = parse_qs(env["QUERY_STRING"]).get("num", ["1"])[0]
+    r = client.adder(int(num))
+    start_response('200 OK', [('Content-Type', 'text/html')])
+    return [str(r).encode()]

--- a/setup-containers.sh
+++ b/setup-containers.sh
@@ -1,9 +1,29 @@
 #!/bin/bash -eux
-echo "Checking sudo permissions to run docker commands"
+CONTAINER_RUNTIME=podman
+if [ -z "$(which podman)" ]; then
+    if [ -z "$(which docker)" ]; then
+        echo "No container runtimes are available please install podman or docker first"
+        exit 1
+    fi
+    CONTAINER_RUNTIME=docker
+fi
+echo "Checking sudo permissions to run ${CONTAINER_RUNTIME} commands"
 sudo true
-sudo docker ps -aq --filter name=oslomsg | xargs --no-run-if-empty sudo docker rm --force
+sudo ${CONTAINER_RUNTIME} ps -aq --filter name=oslomsg | xargs --no-run-if-empty sudo ${CONTAINER_RUNTIME} rm --force
 # use net=host to not deal with intermediate connections
-sudo docker run -d --net=host --hostname my-rabbit --name oslomsg-rabbitmq rabbitmq
-sudo docker exec oslomsg-rabbitmq timeout 20 /bin/bash -c 'while ! rabbitmqctl status &>/dev/null; do sleep 2; done; sleep 2'
-sudo docker exec oslomsg-rabbitmq rabbitmqctl add_user testuser testpwd
-sudo docker exec oslomsg-rabbitmq rabbitmqctl set_permissions -p / testuser '.*' '.*' '.*'
+sudo ${CONTAINER_RUNTIME} run -d \
+    -e RABBITMQ_NODENAME=rabbitmq \
+    -p 5672:5672 \
+    -p 15672:15672 \
+    --net=host \
+    --hostname my-rabbit \
+    --name oslomsg-rabbitmq \
+    rabbitmq:management
+sudo ${CONTAINER_RUNTIME} exec oslomsg-rabbitmq \
+    timeout 40 /bin/bash -c 'while ! rabbitmqctl status &>/dev/null; do sleep 10; done; sleep 2'
+sudo ${CONTAINER_RUNTIME} exec oslomsg-rabbitmq \
+    rabbitmqctl --node rabbitmq add_user testuser testpwd
+sudo ${CONTAINER_RUNTIME} exec oslomsg-rabbitmq \
+    rabbitmqctl set_permissions -p / testuser '.*' '.*' '.*'
+echo "RabbitMQ setup done!"
+echo "Browse the rabbitmq management dashboard at http://127.0.0.1:15672 (user=guest, pwd=guest)"

--- a/setup-containers.sh
+++ b/setup-containers.sh
@@ -1,12 +1,5 @@
 #!/bin/bash -eux
-CONTAINER_RUNTIME=podman
-if [ -z "$(which podman)" ]; then
-    if [ -z "$(which docker)" ]; then
-        echo "No container runtimes are available please install podman or docker first"
-        exit 1
-    fi
-    CONTAINER_RUNTIME=docker
-fi
+source runtime.sh
 echo "Checking sudo permissions to run ${CONTAINER_RUNTIME} commands"
 sudo true
 sudo ${CONTAINER_RUNTIME} ps -aq --filter name=oslomsg | xargs --no-run-if-empty sudo ${CONTAINER_RUNTIME} rm --force

--- a/start-oslo-mod_wsgi.sh
+++ b/start-oslo-mod_wsgi.sh
@@ -1,0 +1,17 @@
+#!/bin/bash -eux
+source runtime.sh
+pkg_name=false
+if [ $# -eq 1 ]; then
+    local_pkg=$1
+    if [ -d ${local_pkg} ]; then
+        pkg_name=$(basename ${local_pkg})
+    fi
+    if [ -d ./${pkg_name} ]; then
+        rm -rf ./${pkg_name}
+    fi
+    cp -r ${local_pkg} ./${pkg_name}
+fi
+rabbit_host=$(sudo ${CONTAINER_RUNTIME} inspect oslomsg-rabbitmq  | niet ".[0].Config.Hostname")
+transport_url="rabbit://testuser:testpwd@${rabbit_host}:5672"
+sudo ${CONTAINER_RUNTIME} build -t oslo_mod_wsgi . --build-arg LOCAL_PKG=${pkg_name} --build-arg TRANSPORT_URL=${transport_url}
+sudo ${CONTAINER_RUNTIME} run -it --rm -p 8000:80 --name oslo_mod_wsgi oslo_mod_wsgi


### PR DESCRIPTION
Some improvement sliced by topics over commits:
### Improve the setup script
- allow user to use podman if available
- activate the rabbitmq management dashboard
- tweak the rabbit starting wait to avoid issue with the add_user on a none properly started server
- display infos to browse the management dashboard

### Using an oslo.messaging local clone to modify it
In a second commit allow users to use/install a local clone of oslo.messaging to lets them debug and test changes interactively by using the available env.

### Allow users to run the server under a monkey patched environment
Choose to start the server in a monkey patched environment.

### Adding a script which look like oslo.messaging unittest related to the heartbeat
(just for testing purpose)

### Adding `test 4` run oslo.messaging heartbeat in a dedicated apache mod_wsgi container monkey patched with eventlet

Introduce oslo.messaging over apache mod_wsgi and monkey patched env
    
These changes introduce a new script and test scenario to run
oslo.messaging server in an apache mod_wsgi containerized environement
and in process which monkey patch the env before starting the oslo.messaging server.

By default the version the system use the upstream release of
oslo.messaging installed from pypi but you also can install/overide
oslo.messaging by installing a local clone (modified or not) by passing
the clone root path to during the script call (cf. README.md test 4 section).