### PR TITLE
Fix the apache mod_wsgi test 4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,8 @@ FROM grahamdumpleton/mod-wsgi-docker:python-3.5-onbuild
 ARG LOCAL_PKG
 ARG TRANSPORT_URL
 RUN mkdir /setup
-ADD ./* /setup
+ADD * /setup
 RUN pip install -r /setup/requirements.txt
 RUN ls /setup
 RUN if [ -d /setup/$LOCAL_PKG ]; then cd /setup/$LOCAL_PKG; python setup.py develop; fi
-CMD ["server.wsgi"]
+CMD ["server-eventlet.wsgi"]

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ in a development mode to let's you tweak, modify and test your changes.
 
 ### Quick setup
 
-```
+```sh
 pipenv install
 pipenv run ./setup-containers.sh
 pipenv shell
@@ -30,7 +30,7 @@ by `pipenv` for you.
 
 ### Debug setup
 
-```
+```sh
 pipenv
 pipenv run ./setup-containers.sh
 pipenv install -e /local/path/to/your/oslo.messaging/clone/oslo.messaging
@@ -51,27 +51,37 @@ test them interactively by using the following scenarios.
 Spawns a oslo.messaging RPC server, running in a standalone python
 process, with native thread polling.
 
-    ./server.py > server.log &
+```sh
+./server.py > server.log &
+```
 
 You can target the server at the command line with:
 
-    ./client.py 42
+```sh
+./client.py 42
+```
 
 Check the AMQP connections to rabbitmq with:
 
-    ss -4tnp | grep 5672
+```sh
+ss -4tnp | grep 5672
+```
 
 ## Test 2: uwsgi api server that contacts the thread-based server
 
 Run the original RPC server as in test 1, and run an additional WSGI
 api hosted by uwsgi:
 
-    ./server.py > server.log &
-    uwsgi --http :9090 --logto uwsgi.log --wsgi-file uwsgi-api.py &
+```sh
+./server.py > server.log &
+uwsgi --http :9090 --logto uwsgi.log --wsgi-file uwsgi-api.py &
+```
 
 this time, the RPC service is accessible on localhost:9090:
 
-    curl http://localhost:9090/\?num\=1336
+```
+curl http://localhost:9090/\?num\=1336
+```
 
 When uwsgi processes an incoming HTTP request, the API services
 receives the query and makes a collateral RPC call to the RPC server.
@@ -84,12 +94,16 @@ hold AMQP connections the rabbitmq server.
 Run the original RPC server as in test 1, and the API service runs
 under a eventlet-based WSGI server:
 
-    ./server.py > server.log &
-    ./eventlet-api.py > eventlet-api.log &
+```sh
+./server.py > server.log &
+./eventlet-api.py > eventlet-api.log &
+```
 
 the RPC service is now accessible on localhost:8090:
 
-    curl http://localhost:8090/\?num\=1336
+```sh
+curl http://localhost:8090/\?num\=1336
+```
 
 As in Test 2, the heartbeat can be inspected after the first API call.
 
@@ -100,7 +114,7 @@ in an apache mod_wsgi environment
 with and monkey patched with eventlet, and the API service runs
 under a eventlet-based WSGI server (by example):
 
-```
+```sh
 pipenv run ./start-oslo-mod_wsgi.sh &
 ./eventlet-api.py > eventlet-api.log &
 ```
@@ -111,7 +125,7 @@ local clone of `oslo.messaging` or a local copy of another dependencies
 (`oslo.utils` by example or `pyamqp`) by passing the root path of your local
 clone as a parameter of your command, like the following example:
 
-```
+```sh
 pipenv run ./start-oslo-mod_wsgi.sh ~/dev/openstack/oslo.messaging &
 ./eventlet-api.py > eventlet-api.log &
 ```
@@ -119,8 +133,112 @@ pipenv run ./start-oslo-mod_wsgi.sh ~/dev/openstack/oslo.messaging &
 Or local clone will be installed and used in your fresh created
 apache mod_wsgi container.
 
-the RPC service is now accessible on localhost:8090:
+the RPC services is now accessible on localhost:8000 (mod_wsgi) and
+localhost:8090 (eventlet-api):
 
-    curl http://localhost:8090/\?num\=1336
+You can send requests to the both by using:
+```sh
+curl 0.0.0.0:8000
+```
+
+```sh
+curl http://localhost:8090/\?num\=1336
+```
 
 As in Test 2, the heartbeat can be inspected after the first API call.
+
+
+## How to reproduce the heartbeat issue
+
+Run the original RPC server as in test 1
+in an apache mod_wsgi environment
+with and monkey patched with eventlet, and the API service runs
+under a eventlet-based WSGI server (by example):
+
+```sh
+pipenv run ./start-oslo-mod_wsgi.sh
+```
+
+the RPC services is now accessible on localhost:8000 (mod_wsgi):
+
+You send a request to it by using:
+
+```sh
+curl 0.0.0.0:8000
+```
+
+Observe your connection appear into the [Rabbit management dashboard](http://127.0.0.1:15672/#/connections)
+and see your connection disapear few secondes/minutes after your request
+
+Now kill your running server and respawn a fresh server by using the server
+without eventlet activated by using:
+
+```sh
+sudo podman run -it \
+    --rm \
+    -p 8000:80 \
+    -e TRANSPORT_URL=rabbit://testuser:testpwd@$(sudo podman inspect oslomsg-rabbitmq  | niet '.[0].NetworkSettings.IPAddress'):5672/ \
+    --name oslo_mod_wsgi \
+    oslo_mod_wsgi \
+    server.wsgi
+```
+
+Now observe your new created connection into the dashboard and observe 
+that this connection still active all the time.
+
+### Advanced usages for test 4
+
+You can choose to start your test by using mod_wsgi like is described in the
+previous section but maybe you want to test behaviours without eventlet turned
+on or with the oslo.messaging server embdded in a high level greenthread, then
+this section is made for you.
+
+In the previous section by using the `start-oslo-mod_wsgi.sh` you have build
+a container image who contains apache and mod_wsgi who will run a wsgi apps that
+will start your oslo.messaging server.
+
+You have choice between 3 apps modes:
+- eventlet turned on and oslo.messaging who will use greenthreads (the default) - `server-eventlet.wsgi`
+- eventlet turned off and oslo.messaging who will use pthreads - `server-eventlet.wsgi`
+- eventlet turned on with your server apps (`server.py.start_server`) which will executed in a greenthread and oslo.messaging who will use greenthread too - `server-eventlet-gthread.wsgi`
+
+To execute a specific mode please use the following command and replace the
+wsgi filename by one of the 3 previous described modes, example `server-eventlet.gthread.wsgi`:
+
+```sh
+sudo podman run -it \
+    --rm \
+    -p 8000:80 \
+    -e TRANSPORT_URL=rabbit://testuser:testpwd@$(sudo podman inspect oslomsg-rabbitmq  | niet '.[0].NetworkSettings.IPAddress'):5672/ \
+    --name oslo_mod_wsgi \
+    oslo_mod_wsgi \
+    server-eventlet-gthread.wsgi # replace the filename here
+```
+
+## Server advanced usages
+
+The server part offer to you few config options like define the rabbit config
+choose the [oslo.messaging executor](https://docs.openstack.org/oslo.messaging/latest/reference/executors.html) (default `threading` here).
+
+To see all the available options use the following command:
+```sh
+./server.py --help
+usage: server.py [-h] [--eventlet-turned-on]
+                 [--heartbeat-timeout HEARTBEAT_TIMEOUT]
+                 [--rabbit-host RABBIT_HOST] [--rabbit-port RABBIT_PORT]
+                 [--rabbit-user RABBIT_USER]
+                 [--rabbit-user-pwd RABBIT_USER_PWD] [--run-oslo-in-thread]
+                 [--oslo-executor OSLO_EXECUTOR]
+
+optional arguments:
+  -h, --help            show this help message and exit
+  --eventlet-turned-on  turn on eventlet and monkey patch the env
+  --heartbeat-timeout HEARTBEAT_TIMEOUT
+                        the heartbeat timeout
+  --rabbit-host RABBIT_HOST
+  --rabbit-port RABBIT_PORT
+  --rabbit-user RABBIT_USER
+  --rabbit-user-pwd RABBIT_USER_PWD
+  --run-oslo-in-thread
+  --oslo-executor OSLO_EXECUTOR
+```

--- a/server-eventlet-gthread.wsgi
+++ b/server-eventlet-gthread.wsgi
@@ -1,5 +1,6 @@
 from urllib.parse import parse_qs
 import os
+from eventlet import greenthread
 import log  # noqa
 import sys
 sys.path.append('/setup')
@@ -7,9 +8,11 @@ import server
 
 
 def application(environ, start_response):
+    server.monkey_patch_if_needed(eventlet_turned_on=True)
     transport_url = os.getenv('TRANSPORT_URL',
         default='rabbit://testuser:testpwd@127.0.0.1:5672/')
-    server.start_server(transport_url)
+    oslo_server = greenthread.spawn(server.start_server,
+        args=(transport_url,))
     num = parse_qs(environ["QUERY_STRING"]).get("num", ["1"])[0]
     start_response('200 OK', [('Content-Type', 'text/html')])
     return [str("it's work").encode()]

--- a/server-eventlet.wsgi
+++ b/server-eventlet.wsgi
@@ -7,6 +7,7 @@ import server
 
 
 def application(environ, start_response):
+    server.monkey_patch_if_needed(eventlet_turned_on=True)
     transport_url = os.getenv('TRANSPORT_URL',
         default='rabbit://testuser:testpwd@127.0.0.1:5672/')
     server.start_server(transport_url)

--- a/setup-containers.sh
+++ b/setup-containers.sh
@@ -8,8 +8,6 @@ sudo ${CONTAINER_RUNTIME} run -d \
     -e RABBITMQ_NODENAME=rabbitmq \
     -p 5672:5672 \
     -p 15672:15672 \
-    --net=host \
-    --hostname my-rabbit \
     --name oslomsg-rabbitmq \
     rabbitmq:management
 sudo ${CONTAINER_RUNTIME} exec oslomsg-rabbitmq \

--- a/start-oslo-mod_wsgi.sh
+++ b/start-oslo-mod_wsgi.sh
@@ -11,7 +11,15 @@ if [ $# -eq 1 ]; then
     fi
     cp -r ${local_pkg} ./${pkg_name}
 fi
-rabbit_host=$(sudo ${CONTAINER_RUNTIME} inspect oslomsg-rabbitmq  | niet ".[0].Config.Hostname")
-transport_url="rabbit://testuser:testpwd@${rabbit_host}:5672"
-sudo ${CONTAINER_RUNTIME} build -t oslo_mod_wsgi . --build-arg LOCAL_PKG=${pkg_name} --build-arg TRANSPORT_URL=${transport_url}
-sudo ${CONTAINER_RUNTIME} run -it --rm -p 8000:80 --name oslo_mod_wsgi oslo_mod_wsgi
+rabbit_host=$(sudo ${CONTAINER_RUNTIME} inspect oslomsg-rabbitmq  | niet ".[0].NetworkSettings.IPAddress")
+transport_url="rabbit://testuser:testpwd@${rabbit_host}:5672/"
+sudo ${CONTAINER_RUNTIME} build --no-cache \
+    -t oslo_mod_wsgi . \
+    --build-arg LOCAL_PKG=${pkg_name} \
+    --build-arg TRANSPORT_URL=${transport_url}
+sudo ${CONTAINER_RUNTIME} run \
+    -it \
+    --rm \
+    -p 8000:80 \
+    -e TRANSPORT_URL=${transport_url} \
+    --name oslo_mod_wsgi oslo_mod_wsgi


### PR DESCRIPTION
These changes fix some mistakes on the test 4:
- bad file path
- avoid to launch a client
- fix variable name
- retrieve rabbitmq server from host (maybe using podman `--host` is more simple)
- fix the `transport_url` issue on `server.py`
- adding CLI options to `server.py`
- introduce 3 modes with mod_wsgi (without eventlet, with eventlet, with the start server in greenthread and + eventlet on heartbeat)
- adding how to reproduce heartbeat issue step by step

I guess I will submit a client to stress (or not) the mod_wsgi server and observe possible behaviours...